### PR TITLE
Feature/sahu/controller

### DIFF
--- a/controller/CMakeLists.txt
+++ b/controller/CMakeLists.txt
@@ -5,12 +5,24 @@ set(CMAKE_CXX_STANDARD 14)
 
 set(BUILD_DEPS
   roscpp
+  genmsg
+  actionlib_msgs
+  actionlib
+  navigation
+  perception
 )
 
 find_package(
   catkin REQUIRED
   ${BUILD_DEPS}
 )
+
+#######################
+## action generation ##
+#######################
+
+add_action_files(DIRECTORY action FILES SetMode.action)
+generate_messages(DEPENDENCIES actionlib_msgs)
 
 ###################################
 ## catkin specific configuration ##

--- a/controller/action/SetMode.action
+++ b/controller/action/SetMode.action
@@ -1,0 +1,10 @@
+# goal
+string mode
+
+---
+# result
+uint32[] objects
+
+---
+# feedback
+uint32[] objects

--- a/controller/include/controller/controller.h
+++ b/controller/include/controller/controller.h
@@ -5,6 +5,11 @@
  */
 
 #include <ros/ros.h>
+#include <actionlib/server/simple_action_server.h>
+
+#include <std_srvs/Trigger.h>
+#include <navigation/SetPoseStamped.h>
+#include <controller/SetModeAction.h>
 
 namespace cleanup {
 
@@ -12,23 +17,21 @@ class Controller {
  public:
   Controller();
 
-  /* @brief Begin exploration behavior. */
-  void explore();
+ private: 
+  /* @brief Callback for action server to set a cleanup mode. */
+  void executeGoal(const controller::SetModeGoal::ConstPtr& goal);
 
-  /* @brief Begin cleaning behavior. */
-  void clean();
+  // navigation service clients
+  ros::ServiceClient goto_client_;
+  ros::ServiceClient stop_client_;
+  ros::ServiceClient explore_client_;
 
-  /* @brief Stop all motion. */
-  void stop();
+  // perception service clients
+  ros::ServiceClient detect_client_;
+  ros::ServiceClient get_pose_client_;
 
- private:
-
-  /* @brief Private method controlling overall exploration processing. */
-  void exploreLoop();
-
-  /* @brief Private method controlling overall cleaning processing. */
-  void cleanLoop();
-
+  // action server handle
+  std::unique_ptr<actionlib::SimpleActionServer<controller::SetModeAction>> as_;
 };
 
 } // namespace cleanup

--- a/controller/launch/cleanup.launch
+++ b/controller/launch/cleanup.launch
@@ -2,6 +2,9 @@
 <launch>
   <arg name="model" default="waffle" doc="Turtlebot3 model type [waffle, waffle_pi]" />
 
+  <!-- launch controller -->
+  <node name="controller" pkg="controller" type="controller_node" output="screen" required="true" />
+
   <!-- launch navigation -->
   <include file="$(find navigation)/launch/navigation.launch">
     <arg name="model" value="$(arg model)" />
@@ -9,7 +12,7 @@
 
   <!-- launch turtlebot3 in gazebo world -->
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
-    <arg name="world_name" value="$(find turtlebot3_gazebo)/worlds/turtlebot3_world.world"/>
+    <arg name="world_name" value="$(find turtlebot3_gazebo)/worlds/turtlebot3_house.world"/>
     <arg name="paused" value="false"/>
     <arg name="use_sim_time" value="true"/>
     <arg name="gui" value="true"/>
@@ -18,7 +21,7 @@
   </include>
 
   <!-- launch robot description and process URDF -->
-  <node pkg="gazebo_ros" type="spawn_model" name="spawn_urdf"  args="-urdf -model turtlebot3_$(arg model) -x -2.0 -y -0.5 -z 0.0 -param robot_description" />
+  <node pkg="gazebo_ros" type="spawn_model" name="spawn_urdf"  args="-urdf -model turtlebot3_$(arg model) -x -2.0 -y 5 -z 0.0 -param robot_description" />
   <param name="robot_description" command="$(find xacro)/xacro $(find turtlebot3_description)/urdf/turtlebot3_$(arg model).urdf.xacro" />
 
   <!-- launch robot state publisher -->

--- a/controller/launch/cleanup.launch
+++ b/controller/launch/cleanup.launch
@@ -21,7 +21,7 @@
   </include>
 
   <!-- launch robot description and process URDF -->
-  <node pkg="gazebo_ros" type="spawn_model" name="spawn_urdf"  args="-urdf -model turtlebot3_$(arg model) -x -2.0 -y 5 -z 0.0 -param robot_description" />
+  <node pkg="gazebo_ros" type="spawn_model" name="spawn_urdf"  args="-urdf -model turtlebot3_$(arg model) -x -2.0 -y 4 -z 0.0 -param robot_description" />
   <param name="robot_description" command="$(find xacro)/xacro $(find turtlebot3_description)/urdf/turtlebot3_$(arg model).urdf.xacro" />
 
   <!-- launch robot state publisher -->

--- a/controller/launch/cleanup.launch
+++ b/controller/launch/cleanup.launch
@@ -1,0 +1,30 @@
+<!-- System launch file: launches full system with Gazebo and RVIZ -->
+<launch>
+  <arg name="model" default="waffle" doc="Turtlebot3 model type [waffle, waffle_pi]" />
+
+  <!-- launch navigation -->
+  <include file="$(find navigation)/launch/navigation.launch">
+    <arg name="model" value="$(arg model)" />
+  </include>
+
+  <!-- launch turtlebot3 in gazebo world -->
+  <include file="$(find gazebo_ros)/launch/empty_world.launch">
+    <arg name="world_name" value="$(find turtlebot3_gazebo)/worlds/turtlebot3_world.world"/>
+    <arg name="paused" value="false"/>
+    <arg name="use_sim_time" value="true"/>
+    <arg name="gui" value="true"/>
+    <arg name="headless" value="false"/>
+    <arg name="debug" value="false"/>
+  </include>
+
+  <!-- launch robot description and process URDF -->
+  <node pkg="gazebo_ros" type="spawn_model" name="spawn_urdf"  args="-urdf -model turtlebot3_$(arg model) -x -2.0 -y -0.5 -z 0.0 -param robot_description" />
+  <param name="robot_description" command="$(find xacro)/xacro $(find turtlebot3_description)/urdf/turtlebot3_$(arg model).urdf.xacro" />
+
+  <!-- launch robot state publisher -->
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" required="true" />
+
+  <!-- launch rviz -->
+  <node name="rviz" type="rviz" pkg="rviz" args="-d $(find turtlebot3_navigation)/rviz/turtlebot3_navigation.rviz" />
+
+</launch>

--- a/controller/package.xml
+++ b/controller/package.xml
@@ -10,6 +10,9 @@
   <depend>roscpp</depend>
   <depend>navigation</depend>
   <depend>perception</depend>
+  <depend>genmsg</depend>
+  <depend>actionlib</depend>
+  <depend>actionlib_msgs</depend>
 
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/controller/src/controller.cpp
+++ b/controller/src/controller.cpp
@@ -9,27 +9,42 @@
 namespace cleanup {
 
 Controller::Controller() {
+  ros::NodeHandle pnh;
+  
+  // construct service clients and wait for the servers to come up
+  goto_client_ = pnh.serviceClient<navigation::SetPoseStamped>("navigation/goto");
+  while (!goto_client_.waitForExistence(ros::Duration(5.0)))
+    ROS_WARN_STREAM("Waiting for navigation goTo service: " << goto_client_.getService());
 
+  stop_client_ = pnh.serviceClient<std_srvs::Trigger>("navigation/stop");
+  while (!stop_client_.waitForExistence(ros::Duration(5.0)))
+    ROS_WARN_STREAM("Waiting for navigation stop service: " << stop_client_.getService());
+
+  explore_client_ = pnh.serviceClient<std_srvs::Trigger>("navigation/explore");
+  while (!explore_client_.waitForExistence(ros::Duration(5.0)))
+    ROS_WARN_STREAM("Waiting for navigation explore service: " << explore_client_.getService());
+
+  // detect_client_ = pnh.serviceClient<perception::DetectObjects>("perception/detect");
+  // while (!detect_client_.waitForExistence(ros::Duration(5.0)))
+  //   ROS_WARN_STREAM("Waiting for perception detectObjects service: " << detect_client_.getService());
+
+  // get_pose_client_ = pnh.serviceClient<perception::GetObjectPose>("perception/get_pose");
+  // while (!get_pose_client_.waitForExistence(ros::Duration(5.0)))
+    // ROS_WARN_STREAM("Waiting for perception getPose service: " << get_pose_client_.getService());
+
+  // start action server to process mode callbacks
+  as_ = std::make_unique<actionlib::SimpleActionServer<controller::SetModeAction>>(
+    pnh,
+    "set_mode",
+    [this](const auto& goal) {this->executeGoal(goal);}
+  );
+  as_->start();
+
+  ROS_INFO("Controller initialized.");
 }
 
-void Controller::explore() {
-
-}
-
-void Controller::clean() {
-
-}
-
-void Controller::stop() {
-
-}
-
-void Controller::exploreLoop() {
-
-}
-
-void Controller::cleanLoop() {
-
+void Controller::executeGoal(const controller::SetModeGoal::ConstPtr& goal) {
+  // @TODO
 }
 
 } // namespace cleanup

--- a/controller/src/controller.cpp
+++ b/controller/src/controller.cpp
@@ -44,7 +44,44 @@ Controller::Controller() {
 }
 
 void Controller::executeGoal(const controller::SetModeGoal::ConstPtr& goal) {
-  // @TODO
+
+  // sanity check goal type
+  if (goal->mode != "clean" && goal->mode != "explore") {
+    ROS_ERROR_STREAM("Invalid goal mode " << goal->mode << ", accepted values are ['clean', 'explore']");
+    as_->setAborted();
+    return;
+  }
+  
+  // initialize loop variables
+  ros::Rate r(10);
+  controller::SetModeFeedback feedback;
+
+  // tell navigation to begin exploring
+  std_srvs::Trigger srv;
+  explore_client_.call(srv);
+
+  // loop until we're canceled, preempted, or ros shuts down
+  while (ros::ok() && as_->isActive()) {
+    // check if we're preempted; if so, exit
+    if (as_->isPreemptRequested()) {
+      as_->setPreempted();
+      break;
+    }
+
+    // otherwise continue performing desired execution mode
+    // @TODO poll perception
+
+    // perform actual cleanup operations
+    if (goal->mode == "clean") {
+      // @TODO implement interface w / moveit
+    }
+
+    // publish feedback
+    as_->publishFeedback(feedback);
+  }
+
+  // perform cleanup / shutdown
+  stop_client_.call(srv);
 }
 
 } // namespace cleanup

--- a/controller/src/controller.cpp
+++ b/controller/src/controller.cpp
@@ -36,7 +36,8 @@ Controller::Controller() {
   as_ = std::make_unique<actionlib::SimpleActionServer<controller::SetModeAction>>(
     pnh,
     "set_mode",
-    [this](const auto& goal) {this->executeGoal(goal);}
+    [this](const auto& goal) {this->executeGoal(goal);},
+    false
   );
   as_->start();
 

--- a/controller/src/controller_node.cpp
+++ b/controller/src/controller_node.cpp
@@ -9,5 +9,12 @@
 #include <controller/controller.h>
 
 int main(int argc, char** argv) {
-  return 0;
+  // initialize ros node
+  ros::init(argc, argv, "controller");
+
+  // construct controller
+  cleanup::Controller controller;
+
+  // process callbacks until shutdown
+  ros::spin();
 }


### PR DESCRIPTION
This Pull Request implements the core controller execution.

A single launch file launches the full stack + gazebo/rviz (perception to be added when complete).
```bash
roslaunch controller cleanup.launch
```

To begin exploration behavior, send a goal to the `/set_mode` action server. Modes can be `explore` or `clean`, e.g.:
```bash
rostopic pub /set_mode/goal controller/SetModeActionGoal "header:
  seq: 0
  stamp:
    secs: 0
    nsecs: 0
  frame_id: ''
goal_id:
  stamp:
    secs: 0
    nsecs: 0
  id: ''
goal:
  mode: 'clean'"
```

Whichever behavior is running can be cancelled via:
```bash
rostopic pub /set_mode/cancel actionlib_msgs/GoalID "stamp:
  secs: 0   
  nsecs: 0    
id: ''" 
```

Note that it's probably easiest to call the above making liberal use of tab completion. The planned `rqt` GUI will just be a wrapper around those calls.