### PR TITLE
Feature/sahu/darknet

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "darknet_ros"]
+	path = darknet_ros
+	url = git@github.com:leggedrobotics/darknet_ros.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "darknet_ros"]
 	path = darknet_ros
-	url = git@github.com:leggedrobotics/darknet_ros.git
+	url = https://github.com/leggedrobotics/darknet_ros.git

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To build the package on Ubuntu 18.04, run the following from a terminal. This wi
 
 ```bash
 mkdir catkin_ws/src -p && cd catkin_ws/src
-git clone https://github.com/danielmohansahu/cleanup-robot.git
+git clone https://github.com/danielmohansahu/cleanup-robot.git --recursive
 cd .. && catkin_make
 ```
 

--- a/controller/launch/cleanup.launch
+++ b/controller/launch/cleanup.launch
@@ -10,6 +10,9 @@
     <arg name="model" value="$(arg model)" />
   </include>
 
+  <!-- launch perception -->
+  <include file="$(find perception)/launch/perception.launch" />
+
   <!-- launch turtlebot3 in gazebo world -->
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(find turtlebot3_gazebo)/worlds/turtlebot3_house.world"/>

--- a/perception/launch/darknet.launch
+++ b/perception/launch/darknet.launch
@@ -3,7 +3,7 @@
 <launch>
   <!-- Console launch prefix -->
   <arg name="launch_prefix" default=""/>
-  <arg name="weights" default="yolov3-tiny.yaml" />
+  <arg name="weights" default="yolov3.yaml" />
   <arg name="image" default="/camera/rgb/image_raw" />
 
   <!-- Config and weights folder. -->

--- a/perception/launch/darknet.launch
+++ b/perception/launch/darknet.launch
@@ -3,7 +3,7 @@
 <launch>
   <!-- Console launch prefix -->
   <arg name="launch_prefix" default=""/>
-  <arg name="weights" default="yolov3.yaml" />
+  <arg name="weights" default="yolov2.yaml" />
   <arg name="image" default="/camera/rgb/image_raw" />
 
   <!-- Config and weights folder. -->

--- a/perception/launch/darknet.launch
+++ b/perception/launch/darknet.launch
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- launch darknet ROS nodes set up to interface with cleanup robot topics -->
+<launch>
+  <!-- Console launch prefix -->
+  <arg name="launch_prefix" default=""/>
+  <arg name="weights" default="yolov3-tiny.yaml" />
+  <arg name="image" default="/camera/rgb/image_raw" />
+
+  <!-- Config and weights folder. -->
+  <arg name="yolo_weights_path"          default="$(find darknet_ros)/yolo_network_config/weights"/>
+  <arg name="yolo_config_path"           default="$(find darknet_ros)/yolo_network_config/cfg"/>
+
+  <!-- ROS and network parameter files -->
+  <arg name="ros_param_file"             default="$(find darknet_ros)/config/ros.yaml"/>
+  <arg name="network_param_file"         default="$(find darknet_ros)/config/$(arg weights)"/>
+
+  <!-- Load parameters -->
+  <rosparam command="load" ns="darknet_ros" file="$(arg ros_param_file)"/>
+  <rosparam command="load" ns="darknet_ros" file="$(arg network_param_file)"/>
+
+  <!-- Start darknet and ros wrapper -->
+  <node pkg="darknet_ros" type="darknet_ros" name="darknet_ros" output="screen" launch-prefix="$(arg launch_prefix)">
+    <param name="weights_path"          value="$(arg yolo_weights_path)" />
+    <param name="config_path"           value="$(arg yolo_config_path)" />
+    <remap from="camera/rgb/image_raw"  to="$(arg image)" />
+  </node>
+
+</launch>

--- a/perception/launch/perception.launch
+++ b/perception/launch/perception.launch
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<launch>
+
+  <!-- launch perception node -->
+  <!-- @TODO -->
+
+  <!-- launch darknet -->
+  <include file="$(find perception)/launch/darknet.launch" />
+
+</launch>


### PR DESCRIPTION
This PR adds the [darknet_ros](https://github.com/leggedrobotics/darknet_ros) packages as a submodule.

Note that you'll need to do some extra stuff to get this working from an existing branch, i.e.:
```bash
git submodule update --init --recursive
```

To verify that this was build properly you can run their tests:
```bash
catkin build darknet_ros --no-deps --verbose --catkin-make-args run_tests 
```

I've also added the `darknet_ros` node launch into the main system launch:
```bash
roslaunch controller cleanup.launch
```